### PR TITLE
Fix Page Fault while using Resolution lower than 1920x1080

### DIFF
--- a/ringOS-Beta17/src/kernel.cpp
+++ b/ringOS-Beta17/src/kernel.cpp
@@ -23,7 +23,7 @@ extern "C" void _start(BootInfo* bootInfo)
     GlobalRenderer->ClearColour = 0x00000000;
     GlobalRenderer->Clear();
 
-    GlobalRenderer->BMPPicture();
+    if(ResoWidth >= 1920 && ResoHeight >= 1080) GlobalRenderer->BMPPicture();
 
     //taskbar
     switch (ResoWidth | ResoHeight)


### PR DESCRIPTION
The image is causing the page fault, so it will stop rendering if the Resolution is lower than 1920x1080