### PR TITLE
Fix character encoding error by rewrite script, remove sudo in all script

### DIFF
--- a/install-scripts/ringOS-beta-arch.sh
+++ b/install-scripts/ringOS-beta-arch.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 echo "ringOS beta builder for Arch(-based) Linux"
-echo "This script will ask you for password using sudo."
+echo "Please run this script as root."
 
-sudo pacman -Sy base-devel mtools && echo base-devel and mtools installed successfully || echo FAILED to install base-devel and/or mtools
-sudo pacman -S mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential tools
-sudo pacman -S nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo pacman -S qemu-x86_64 && echo Qemu installed successfully || echo FAILED to install Qemu
-sudo pacman -S git && echo git installed successfully || echo FAILED to install git
-sudo pacman -S lld && echo lld installed successfully || echo FAILED to install lld
-sudo pacman -S xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo pacman -Ss mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+pacman -Sy base-devel mtools && echo base-devel and mtools installed successfully || echo FAILED to install base-devel and/or mtools
+pacman -S mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential tools
+pacman -S nasm && echo NASM installed successfully || echo FAILED to install nasm
+pacman -S qemu-x86_64 && echo Qemu installed successfully || echo FAILED to install Qemu
+pacman -S git && echo git installed successfully || echo FAILED to install git
+pacman -S lld && echo lld installed successfully || echo FAILED to install lld
+pacman -S xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+pacman -Ss mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 git clone https://github.com/ringwormGO-organization/ringOS
 
@@ -18,3 +18,4 @@ cd ringOS
 
 chmod +x ./compile.sh
 ./compile.sh
+

--- a/install-scripts/ringOS-beta-debian.sh
+++ b/install-scripts/ringOS-beta-debian.sh
@@ -3,14 +3,14 @@
 echo "ringOS beta builder for Debian(-based) Linux"
 echo "This script will ask you for password using sudo."
 
-sudo apt-get update && echo Repository update successful || echo FAILED to update the repository
-sudo apt-get install build-essential mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential and/or mtools
-sudo apt-get install nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo apt-get install qemu-system-x86 && echo Qemu installed successfully || echo FAILED to install Qemu
-sudo apt-get install git && echo git installed successfully || echo FAILED to install git
-sudo apt-get install lld && echo lld installed successfully || echo FAILED to install lld
-sudo apt-get install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo apt-get install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+apt-get update && echo Repository update successful || echo FAILED to update the repository
+apt-get install build-essential mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential and/or mtools
+apt-get install nasm && echo NASM installed successfully || echo FAILED to install nasm
+apt-get install qemu-system-x86 && echo Qemu installed successfully || echo FAILED to install Qemu
+apt-get install git && echo git installed successfully || echo FAILED to install git
+apt-get install lld && echo lld installed successfully || echo FAILED to install lld
+apt-get install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+apt-get install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 git clone https://github.com/ringwormGO-organization/ringOS
 
@@ -18,3 +18,4 @@ cd ringOS
 
 chmod +x ./compile.sh
 ./compile.sh
+

--- a/install-scripts/ringOS-beta-redhat.sh
+++ b/install-scripts/ringOS-beta-redhat.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 
 echo "ringOS beta builder for Fedora(-based) Linux"
-echo "This script will ask you for password using sudo."
+echo "Please run this script as root."
 echo "Note: On Red Hat Enterprise Linux & CentOS, you might need to install the EPEL repository. "
 echo "THIS SCRIPT HAS NOT BEEN TESTED AND IT IS EXTREMELY UNSTABLE! USE WITH CAUTION!!!!!!! IF YOU WANT TO IMPROVE, CONSIDER A PULL REQUEST."
+echo "Note: To install NASM on CentOS or RHEL, you will need to enable the CodeReady Linux Builder (PowerTools) repository. "
 
-sudo yum check-update && echo Check for update successful || echo FAILED to check for update
-sudo yum group install "Development tools" && echo Development tools installed successfully || echo FAILED to install Development tools
-sudo yum install nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo yum install qemu-kvm && echo Qemu-kvm installed successfully || echo FAILED to install Qemu-kvm
-sudo yum install git && echo git installed successfully || echo FAILED to install git
-sudo yum install lld && echo lld installed successfully || echo FAILED to install lld
-sudo yum install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo yum install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+yum check-update && echo Check for update successful || echo FAILED to check for update
+yum group install "Development tools" && echo Development tools installed successfully || echo FAILED to install Development tools
+yum install nasm && echo NASM installed successfully || echo FAILED to install nasm
+yum install qemu-kvm && echo Qemu-kvm installed successfully || echo FAILED to install Qemu-kvm
+yum install git && echo git installed successfully || echo FAILED to install git
+yum install lld && echo lld installed successfully || echo FAILED to install lld
+yum install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+yum install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 git clone https://github.com/ringwormGO-organization/ringOS
 
 cd ringOS
+
+sed -i 's/qemu-system-x86_64/"\/usr\/libexec\/qemu-kvm"/g' GNUmakefile
 
 chmod +x ./compile.sh
 ./compile.sh

--- a/install-scripts/ringOS-stable-Builder-arch.sh
+++ b/install-scripts/ringOS-stable-Builder-arch.sh
@@ -2,14 +2,14 @@
 
 clear
 
-sudo pacman -Sy base-devel mtools && echo base-devel installed successfully || echo FAILED to install base-devel
-sudo pacman -S mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential tools
-sudo pacman -S nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo pacman -S qemu-x86_64 && echo Qemu installed successfully || echo FAILED to install Qemu
-sudo pacman -S git && echo git installed successfully || echo FAILED to install git
-sudo pacman -S lld && echo lld installed successfully || echo FAILED to install lld
-sudo pacman -S xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo pacman -Ss mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+pacman -Sy base-devel mtools && echo base-devel installed successfully || echo FAILED to install base-devel
+pacman -S mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential tools
+pacman -S nasm && echo NASM installed successfully || echo FAILED to install nasm
+pacman -S qemu-x86_64 && echo Qemu installed successfully || echo FAILED to install Qemu
+pacman -S git && echo git installed successfully || echo FAILED to install git
+pacman -S lld && echo lld installed successfully || echo FAILED to install lld
+pacman -S xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+pacman -Ss mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 mkdir "ringOS-stable" && echo ringOS-stable directory successfully created || echo FAILED to create ringOS directory
 
@@ -28,3 +28,4 @@ make buildimg && echo Buildimg successfully created || echo FAILED to create bui
 chmod +x ./ISO.sh
 ./ISO.sh
 make run && echo Successfully run ringOS stable release || echo FAILED run ringOS stable release
+

--- a/install-scripts/ringOS-stable-Builder-debian.sh
+++ b/install-scripts/ringOS-stable-Builder-debian.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 echo "ringOS stable builder for Debian(-based) Linux"
-echo "This script will ask you for password using sudo."
+echo "This script will ask you for password using ."
 
-sudo apt-get update && echo Repository update successful || echo FAILED to update the repository
-sudo apt-get install build-essential mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential mtools
-sudo apt-get install nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo apt-get install qemu-system-x86 && echo Qemu installed successfully || echo FAILED to install Qemu
-sudo apt-get install git && echo git installed successfully || echo FAILED to install git
-sudo apt-get install lld && echo lld installed successfully || echo FAILED to install lld
-sudo apt-get install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo apt-get install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+apt-get update && echo Repository update successful || echo FAILED to update the repository
+apt-get install build-essential mtools && echo build-essential mtools installed successfully || echo FAILED to install build-essential mtools
+apt-get install nasm && echo NASM installed successfully || echo FAILED to install nasm
+apt-get install qemu-system-x86 && echo Qemu installed successfully || echo FAILED to install Qemu
+apt-get install git && echo git installed successfully || echo FAILED to install git
+apt-get install lld && echo lld installed successfully || echo FAILED to install lld
+apt-get install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+apt-get install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 mkdir "ringOS-stable" && echo ringOS-stable directory successfully created || echo FAILED to create ringOS directory
 
@@ -29,3 +29,4 @@ make buildimg && echo Buildimg successfully created || echo FAILED to create bui
 chmod +x ./ISO.sh
 ./ISO.sh
 make run && echo Successfully run ringOS stable release || echo FAILED run ringOS stable release
+

--- a/install-scripts/ringOS-stable-Builder-redhat.sh
+++ b/install-scripts/ringOS-stable-Builder-redhat.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 echo "ringOS stable builder for Fedora(-based) Linux"
-echo "This script will ask you for password using sudo."
+echo "This script will ask you for password using ."
 echo "Note: On Red Hat Enterprise Linux & CentOS, you might need to install the EPEL repository. "
 echo "THIS SCRIPT HAS NOT BEEN TESTED AND IT IS EXTREMELY UNSTABLE! USE WITH CAUTION!!!!!!! IF YOU WANT TO IMPROVE, CONSIDER A PULL REQUEST."
+echo "Note: To install NASM on CentOS & RHEL, please enable the CodeReady Linux Builder (PowerTools) repository. "
 
-sudo yum check-update && echo Check for update successful || echo FAILED to check for update
-sudo yum group install "Development tools" && echo Development tools installed successfully || echo FAILED to install Development tools
-sudo yum install nasm && echo NASM installed successfully || echo FAILED to install nasm
-sudo yum install qemu-kvm && echo Qemu-kvm installed successfully || echo FAILED to install Qemu-kvm
-sudo yum install git && echo git installed successfully || echo FAILED to install git
-sudo yum install lld && echo lld installed successfully || echo FAILED to install lld
-sudo yum install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
-sudo yum install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
+yum check-update && echo Check for update successful || echo FAILED to check for update
+yum group install "Development tools" && echo Development tools installed successfully || echo FAILED to install Development tools
+yum install nasm && echo NASM installed successfully || echo FAILED to install nasm
+yum install qemu-kvm && echo Qemu-kvm installed successfully || echo FAILED to install Qemu-kvm
+yum install git && echo git installed successfully || echo FAILED to install git
+yum install lld && echo lld installed successfully || echo FAILED to install lld
+yum install xorriso && echo xorriso installed successfully || echo FAILED to install xorriso
+yum install mkisofs && echo mkisofs installed successfully || echo FAILED to install mkisofs
 
 mkdir "ringOS-stable" && echo ringOS-stable directory successfully created || echo FAILED to create ringOS directory
 
@@ -26,8 +27,10 @@ cd ringOS && echo In ringOS directory || echo FAILED to enter ringOS directory
 cd gnu-efi && echo In gnu-efi directory || echo FAILED to enter gnu-efi directory
 make bootloader && echo Bootloader successfully created || echo FAILED to create bootloader
 cd ../kernel && echo In kernel directory || echo FAILED to enter kernel directory
+sed -i 's/qemu-system-x86_64/\/usr\/libexec\/qemu-kvm/g' Makefile
 make kernel && echo Kernel successfully created || echo FAILED to create kernel
 make buildimg && echo Buildimg successfully created || echo FAILED to create buildimg
 chmod +x ./ISO.sh
 ./ISO.sh
 make run && echo Successfully run ringOS stable release || echo FAILED run ringOS stable release
+


### PR DESCRIPTION
Those ringOS builder scripts all having encoding error. I fixed it by rewrite all of them.
Image: 
![image](https://user-images.githubusercontent.com/86903124/171832643-05f6807c-b077-4818-945d-0e57e6a9fc42.png)

It is inconvenient to build in container that doesn't have enough features like a complete operating system. Why install sudo? I removed sudo in all those builder scripts.

Update for Fedora(-based) distros: Using /usr/libexec/qemu-kvm instead of qemu-system-x86_64. If you use Fedora(-based) distros those script will change makefile with sed.

Add notice for CentOS and RHEL users: You must enable CodeReady Linux Builder repository before installing nasm. There is no way that compatible with both CentOS and RHEL to enable CRB repository.